### PR TITLE
Bugfix - Having multiple rolls with multiple labels in the same query consumes rolls as label content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>co.uk.binaryoverload</groupId>
     <artifactId>DiceRollParser</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/src/main/java/uk/co/binaryoverload/dicerollparser/Parser.java
+++ b/src/main/java/uk/co/binaryoverload/dicerollparser/Parser.java
@@ -36,7 +36,7 @@ public class Parser {
                         ")+" + // One or more selectors
                     ")?" +
                     "((?:[+\\-*/]\\d+)+(?!d))?" + // Capture Group 4 (Is optional), matches a list of operators (+4*3)
-                    "(?:\\[(.+)])?"+ // Capture Group 5 (Is optional), matches a [label] with any text inside
+                    "(?:\\[([^\\]]+)])?"+ // Capture Group 5 (Is optional), matches a [label] with any text inside
                     "(?:([+\\-*/])|$)"); // Capture Group 6, matches the operator between dice rolls
             //@formatter:off
 


### PR DESCRIPTION
- Prevented the roll parser from accepting "]" as a valid character within a label.
    - Caused an unexpected behaviour where, if multiple labels were used in one roll query, it would consume the other rolls as label text.
    - Example: `1d20[cold]+1d20[fire]` parsed into 1 d20 roll with the label "cold]+1d20[fire"
    - This is now fixed. I have re-tested the example queries to make sure they're all working fine, and that seems to be the case (I literally just added "\\]" to the label regex so it really shouldn't be an issue)
- Updated version to 1.0.1, for Maven reasons.
- I know, I know, it's a one-liner. I'm sorry :(

also hi binary :D